### PR TITLE
v.1.0.3 client streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Fix response message being truncated. Change `client.py` to request `stream=True` and error message to include `response.content`. Decrease `sync.py` batch size to `pg_size = 100`.
+
 ## 1.0.2
   * Upgrade `singer-python` and `requests` libraries. Reduce batch sizes. Better error logging in `client.py` to log `unterminated string` error results.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -171,7 +171,7 @@ class RechargeClient(object):
             kwargs['headers']['Content-Type'] = 'application/json'
 
         with metrics.http_request_timer(endpoint) as timer:
-            response = self.__session.request(method, url, **kwargs)
+            response = self.__session.request(method, url, stream=True, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
 
         if response.status_code >= 500:
@@ -185,7 +185,7 @@ class RechargeClient(object):
             response_json = response.json()
         except Exception as err:
             LOGGER.error('{}'.format(err))
-            LOGGER.error('response: {}'.format(response.text))
+            LOGGER.error('response content: {}'.format(response.content))
             raise Exception(err)
 
         return response_json

--- a/tap_recharge/sync.py
+++ b/tap_recharge/sync.py
@@ -126,7 +126,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 
     # pagination: loop thru all pages of data
     page = 1
-    pg_size = 200
+    pg_size = 100
     from_rec = 1
     record_count = pg_size # initial value, set with first API call
     total_records = 0


### PR DESCRIPTION
# Description of change
Fix response message being truncated. Change `client.py` to request `stream=True` and error message to include `response.content`. Decrease `sync.py` batch size to `pg_size = 100`.

# Manual QA steps
Ran singer-discover, singer-check-tap, target-stitch sync (initial and incremental) for all endpoints. No errors. Verified data.

# Risks
Low. Only a few beta clients. Attempting to fix response truncating issue with very large response in client data.

# Rollback steps
Revert to v.1.0.2
