### PR TITLE
Rate limits

### DIFF
--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -141,7 +141,7 @@ class RechargeClient(object):
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=5,
                           factor=2)
-    # Call/rate limit: https://developer.rechargepayments.com/#call-limit
+    # Call/rate limit: https://developer.rechargepayments.com/#rate-limits
     @utils.ratelimit(120, 60)
     def request(self, method, path=None, url=None, **kwargs):
         if not self.__verified:

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -142,7 +142,7 @@ class RechargeClient(object):
                           max_tries=5,
                           factor=2)
     # Call/rate limit: https://developer.rechargepayments.com/#call-limit
-    @utils.ratelimit(160, 60)
+    @utils.ratelimit(120, 60)
     def request(self, method, path=None, url=None, **kwargs):
         if not self.__verified:
             self.__verified = self.check_access_token()


### PR DESCRIPTION
# Description of change
ReCharge rate limits have changed which causes a 429 ERROR. Connector is broken on Stitch.

Current rate limit is `(160,60)`.

However, from Recharge Documentation:

https://developer.rechargepayments.com/#rate-limits

> The API call limit operates using a “leaky bucket” algorithm as a controller. This allows for infrequent bursts of calls and allows your app to continue to make an unlimited amount of calls over time. The bucket size is 40 calls (which cannot be exceeded at any given time), with a “leak rate” of 2 calls per second that continually empties the bucket. If your app averages 2 calls per second, it will never trip a 429 error (“bucket overflow”).

Proposed change is to alter rate limits to `(120,60)` to never trip 429 error.

# Manual QA steps
Couldn't manual QA cannot get dependencies working on Mac w/ M1 Chip. Think this PR is low risk. Would appreciate some help with QA if 100% necessary. Connector is broken in current form.
 
# Risks
Low. Only proposed a reduction in the calls per minute.
 
# Rollback steps
Revert to v1.0.3.
