### PR TITLE
Fix unterminated strings issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 1 1.2
+## 1 1.3
+  * Minor change to improve unterminated string error handling [issue #4](https://github.com/singer-io/tap-recharge/issues/4)
+
+## 1.1.2
   * Request timeout functionality added [#19](https://github.com/singer-io/tap-recharge/pull/19)
 ## 1.1.1
   * Fix bookmark access [#17](https://github.com/stitchdata/sources-utils/pull/17)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='1.1.2',
+      version='1.1.3',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -6,7 +6,7 @@ from singer import metrics, utils
 from requests.exceptions import Timeout
 
 LOGGER = singer.get_logger()
-REQUEST_TIMEOUT = 300
+REQUEST_TIMEOUT = 600
 
 class Server5xxError(Exception):
     pass
@@ -202,13 +202,54 @@ class RechargeClient:
         if response.status_code != 200:
             raise_for_error(response)
 
+        # Intermittent JSONDecodeErrors when parsing JSON; Adding 2 attempts
+        # FIRST ATTEMPT
+        with metrics.http_request_timer(endpoint) as timer:
+            response = self.__session.request(method, url, stream=True, timeout=self.request_timeout, **kwargs)
+            timer.tags[metrics.Tag.http_status_code] = response.status_code
+
+        if response.status_code >= 500:
+            raise Server5xxError()
+
+        if response.status_code == 429:
+            raise Server429Error()
+
+        if response.status_code != 200:
+            raise_for_error(response)
+
+        # Catch invalid JSON (e.g. unterminated string errors)
+        try:
+            response_json = response.json()
+            return response_json, response.links
+        except ValueError as err:  # includes simplejson.decoder.JSONDecodeError
+            LOGGER.warn(err)
+
+        # SECOND ATTEMPT, if there is a ValueError (unterminated string error)
+        with metrics.http_request_timer(endpoint) as timer:
+            response = self.__session.request(
+                method,
+                url,
+                stream=True,
+                timeout=self.request_timeout,
+                **kwargs)
+            timer.tags[metrics.Tag.http_status_code] = response.status_code
+
+        if response.status_code >= 500:
+            raise Server5xxError()
+
+        if response.status_code == 429:
+            raise Server429Error()
+
+        if response.status_code != 200:
+            raise_for_error(response)
+
         # Log invalid JSON (e.g. unterminated string errors)
         try:
             response_json = response.json()
-        except Exception as err:
+            return response_json, response.links
+        except ValueError as err:  # includes simplejson.decoder.JSONDecodeError
             LOGGER.error(err)
             raise Exception(err)
-        return response_json, response.links
 
     def get(self, path, **kwargs):
         return self.request('GET', path=path, **kwargs)

--- a/tap_recharge/streams.py
+++ b/tap_recharge/streams.py
@@ -14,7 +14,7 @@ from tap_recharge.client import RechargeClient
 
 LOGGER = singer.get_logger()
 
-MAX_PAGE_LIMIT = 250
+MAX_PAGE_LIMIT = 50
 
 
 def get_recharge_bookmark(


### PR DESCRIPTION
Fix unterminated strings [issue #4](https://github.com/singer-io/tap-recharge/issues/4)

# Description of change
Increased request timeout, decreased max page limit, and added a retry for unterminated strings errors in client.

# Manual QA steps
Ran singer-discover for Discovery for ALL endpoints and fields: no errors. Ran singer-check-tap for ALL endpoints: no errors. Ran target-stitch import API for ALL endpoints with previous state file: no errors.
 
# Risks
Low risk. No new endpoints or fields. Uses same version of the Recharge API. Only minor change to fix intermittent unterminated string errors.
 
# Rollback steps
Revert this branch to 1.1.2
