### PR TITLE
429 retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1 1.4
+  * Minor change due to intermittent 429 errors: 1) Reduce client rate limit from 120 per 60s to 100 per 60s; 2) Add a 5s time delay/retry when 429 error occurs. [Recharge Leaky Bucket Rate Limits](https://docs.rechargepayments.com/docs/api-rate-limits)
+
 ## 1 1.3
   * Minor change to improve unterminated string error handling [issue #4](https://github.com/singer-io/tap-recharge/issues/4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 1 1.4
+## 1.1.4
   * Minor change due to intermittent 429 errors: 1) Reduce client rate limit from 120 per 60s to 100 per 60s; 2) Add a 5s time delay/retry when 429 error occurs. [Recharge Leaky Bucket Rate Limits](https://docs.rechargepayments.com/docs/api-rate-limits)
 
-## 1 1.3
+## 1.1.3
   * Minor change to improve unterminated string error handling [issue #4](https://github.com/singer-io/tap-recharge/issues/4)
 
 ## 1.1.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='1.1.3',
+      version='1.1.4',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Minor change to reduce rate limit from 120 per 60 seconds to 100 per 60 seconds; and add a 5 second delay to backoff when 429 errors occur. This will reduce/eliminate intermittent 429 errors due to the Recharge API Leaky Bucket Rate Limit algorithm (https://docs.rechargepayments.com/docs/api-rate-limits).

# Manual QA steps
Ran singer-discover, singer-check-tap, and sync to target-stitch (with state and without state) for ALL endpoints. No issues/errors.
 
# Risks
 Low risk - just a minor change to rate limits and adding a delay when 429 errors occur.
 
# Rollback steps
Revert to version 1.1.3
