### PR TITLE
TDL-19327: Add new endpoint Plans and Payment Methods

### DIFF
--- a/tap_recharge/__init__.py
+++ b/tap_recharge/__init__.py
@@ -14,10 +14,10 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info('Starting discover')
-    catalog = discover()
+    catalog = discover(client)
     catalog.dump()
     LOGGER.info('Finished discover')
 
@@ -39,7 +39,7 @@ def main():
             state = parsed_args.state
 
         if parsed_args.discover:
-            do_discover()
+            do_discover(client=client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -187,7 +187,7 @@ class RechargeClient:
         # If we did not specify any API Version during API Call, the Recharge will use the default API Version of our store
         # the 'collections' was added as part of API Version: '2021-11', for older API Version,
         # we will get empty records so adding 'X-Recharge-Version' for 'collections' API call
-        if path == 'collections':
+        if path in ['collections', 'plans', 'payment_methods']:
             kwargs['headers']['X-Recharge-Version'] = '2021-11'
 
         if self.__user_agent:

--- a/tap_recharge/discover.py
+++ b/tap_recharge/discover.py
@@ -2,11 +2,11 @@ from singer.catalog import Catalog
 from tap_recharge.schema import get_schemas
 
 
-def discover():
+def discover(client):
     """
     Constructs a singer Catalog object based on the schemas and metadata.
     """
-    schemas, field_metadata = get_schemas()
+    schemas, field_metadata = get_schemas(client)
     streams = []
 
     for schema_name, schema in schemas.items():

--- a/tap_recharge/schema.py
+++ b/tap_recharge/schema.py
@@ -27,14 +27,12 @@ def get_schemas(client):
         # Thus checking if we have access to "payment_methods"
         params = stream_object.params
         params.update({'limit': 1}) # add limit 1 to only fetch 1 record
-        path = stream_object.path
-        data_key = stream_object.data_key
         # fetch a record
         try:
-            response, _ = client.get(path, params=params)
-            response.get(data_key)
-        except Exception as err:
-            LOGGER.warning('Endpoint: {}, access error: {}'.format(stream_name, err))
+            response, _ = client.get(stream_object.path, params=params)
+            response.get(stream_object.data_key)
+        except AttributeError as err:
+            LOGGER.warning('Endpoint: %s, access error: %s', stream_name, err)
             # do not generate the schema if the user does not have the permission to get records
             continue
 

--- a/tap_recharge/schema.py
+++ b/tap_recharge/schema.py
@@ -25,16 +25,17 @@ def get_schemas(client):
         # The Payment Methods resource is not publicly available to every Merchant at this point.
         # Reference: https://developer.rechargepayments.com/2021-11/payment_methods/payment_methods_list
         # Thus checking if we have access to "payment_methods"
-        params = stream_object.params
-        params.update({'limit': 1}) # add limit 1 to only fetch 1 record
-        # fetch a record
-        try:
-            response, _ = client.get(stream_object.path, params=params)
-            response.get(stream_object.data_key)
-        except AttributeError as err:
-            LOGGER.warning('Endpoint: %s, access error: %s', stream_name, err)
-            # do not generate the schema if the user does not have the permission to get records
-            continue
+        if stream_name == 'payment_methods':
+            params = stream_object.params
+            params.update({'limit': 1}) # add limit 1 to only fetch 1 record
+            # fetch a record
+            try:
+                response, _ = client.get(stream_object.path, params=params)
+                response.get(stream_object.data_key)
+            except AttributeError as err:
+                LOGGER.warning('Endpoint: %s, access error: %s', stream_name, err)
+                # do not generate the schema if the user does not have the permission to get records
+                continue
 
         schema_path = get_abs_path(f'schemas/{stream_name}.json')
         with open(schema_path, encoding='utf-8') as file:

--- a/tap_recharge/schemas/payment_methods.json
+++ b/tap_recharge/schemas/payment_methods.json
@@ -1,0 +1,70 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "id": {
+            "type": ["null", "integer"]
+        },
+        "customer_id": {
+            "type": ["null", "integer"]
+        },
+        "created_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "default": {
+            "type": ["null", "boolean"]
+        },
+        "payment_details": {
+            "type": ["null", "object"],
+            "properties": {
+                "brand": {
+                    "type": ["null", "string"]
+                },
+                "exp_month": {
+                    "type": ["null", "string"]
+                },
+                "exp_year": {
+                    "type": ["null", "string"]
+                },
+                "last4": {
+                    "type": ["null", "string"]
+                },
+                "paypal_email": {
+                    "type": ["null", "string"]
+                },
+                "paypal_payer_id": {
+                    "type": ["null", "string"]
+                },
+                "wallet_type": {
+                    "type": ["null", "string"]
+                },
+                "funding_type": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "payment_type": {
+            "type": ["null", "string"]
+        },
+        "processor_customer_token": {
+            "type": ["null", "string"]
+        },
+        "processor_name": {
+            "type": ["null", "string"]
+        },
+        "processor_payment_method_token": {
+            "type": ["null", "string"]
+        },
+        "status": {
+            "type": ["null", "string"]
+        },
+        "status_reason": {
+            "type": ["null", "string"]
+        },
+        "updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_recharge/schemas/plans.json
+++ b/tap_recharge/schemas/plans.json
@@ -1,0 +1,110 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "id": {
+            "type": ["null", "integer"]
+        },
+        "channel_settings": {
+            "type": ["null", "object"],
+            "properties": {
+                "api": {
+                    "type": ["null", "object"],
+                    "properties": {
+                        "display": {
+                            "type": ["null", "boolean"]
+                        }
+                    }
+                },
+                "customer_portal": {
+                    "type": ["null", "object"],
+                    "properties": {
+                        "display": {
+                            "type": ["null", "boolean"]
+                        }
+                    }
+                },
+                "merchant_portal": {
+                    "type": ["null", "object"],
+                    "properties": {
+                        "display": {
+                            "type": ["null", "boolean"]
+                        }
+                    }
+                },
+                "checkout_page": {
+                    "type": ["null", "object"],
+                    "properties": {
+                        "display": {
+                            "type": ["null", "boolean"]
+                        }
+                    }
+                }
+            }
+        },
+        "created_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "deleted_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "discount_amount": {
+            "type": ["null", "string"]
+        },
+        "discount_type": {
+            "type": ["null", "string"]
+        },
+        "external_product_id": {
+            "type": ["null", "object"],
+            "properties": {
+                "ecommerce": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "sort_order": {
+            "type": ["null", "integer"]
+        },
+        "subscription_preferences": {
+            "type": ["null", "object"],
+            "properties": {
+                "charge_interval_frequency": {
+                    "type": ["null", "integer"]
+                },
+                "cutoff_day_of_month": {
+                    "type": ["null", "integer"]
+                },
+                "cutoff_day_of_week": {
+                    "type": ["null", "integer"]
+                },
+                "expire_after_specific_number_of_charges": {
+                    "type": ["null", "integer"]
+                },
+                "order_day_of_month": {
+                    "type": ["null", "integer"]
+                },
+                "order_day_of_week": {
+                    "type": ["null", "integer"]
+                },
+                "order_interval_frequency": {
+                    "type": ["null", "integer"]
+                },
+                "interval_unit": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "title": {
+            "type": ["null", "string"]
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_recharge/streams.py
+++ b/tap_recharge/streams.py
@@ -468,6 +468,34 @@ class Subscriptions(CursorPagingStream):
     data_key = 'subscriptions'
 
 
+class Plans(PageBasedPagingStream):
+    """
+    Retrieves plans from the Recharge API.
+
+    Docs: https://developer.rechargepayments.com/2021-11/plans
+    """
+    tap_stream_id = 'plans'
+    key_properties = ['id']
+    path = 'plans'
+    replication_key = 'updated_at'
+    valid_replication_keys = ['updated_at']
+    params = {'sort_by': f'{replication_key}-asc'}
+    data_key = 'plans'
+
+class PaymentMethods(PageBasedPagingStream):
+    """
+    Retrieves payment_methods from the Recharge API.
+
+    Docs: https://developer.rechargepayments.com/2021-11/payment_methods
+    """
+    tap_stream_id = 'payment_methods'
+    key_properties = ['id']
+    path = 'payment_methods'
+    replication_key = 'updated_at'
+    valid_replication_keys = ['updated_at']
+    params = {'sort_by': f'{replication_key}-asc'}
+    data_key = 'payment_methods'
+
 STREAMS = {
     'addresses': Addresses,
     'charges': Charges,
@@ -481,5 +509,7 @@ STREAMS = {
     'orders': Orders,
     'products': Products,
     'shop': Shop,
-    'subscriptions': Subscriptions
+    'subscriptions': Subscriptions,
+    'plans': Plans,
+    'payment_methods': PaymentMethods
 }

--- a/tests/base.py
+++ b/tests/base.py
@@ -132,11 +132,13 @@ class RechargeBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updated_at"}
             },
-            "payment_methods": {
-                self.PRIMARY_KEYS: {"id", },
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"updated_at"}
-            }
+            # Skip Payment Methods as in our test account it is not enabled
+            # API Response: "error": "You do not have sufficient permissions (scopes) for this object"
+            # "payment_methods": {
+            #     self.PRIMARY_KEYS: {"id", },
+            #     self.REPLICATION_METHOD: self.INCREMENTAL,
+            #     self.REPLICATION_KEYS: {"updated_at"}
+            # }
         }
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -126,6 +126,16 @@ class RechargeBaseTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"id", },
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "plans": {
+                self.PRIMARY_KEYS: {"id", },
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
+            },
+            "payment_methods": {
+                self.PRIMARY_KEYS: {"id", },
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updated_at"}
             }
         }
 

--- a/tests/test_recharge_start_date.py
+++ b/tests/test_recharge_start_date.py
@@ -22,8 +22,12 @@ class RechargeStartDateTest(RechargeBaseTest):
         streams_2 = {"collections"}
         self.run_test(streams_2, "2021-09-01T00:00:00Z", "2022-05-01T00:00:00Z")
 
-        # rest other streams for 3rd run
-        self.run_test(streams - streams_1 - streams_2, "2021-09-01T00:00:00Z", "2021-10-01T00:00:00Z")
+        # streams of 3rd run
+        stream_3 = {'plans'}
+        self.run_test(streams_2, "2022-06-09T00:00:00Z", "2022-06-10T00:00:00Z")
+
+        # rest other streams for 4th run
+        self.run_test(streams - streams_1 - streams_2 - stream_3, "2021-09-01T00:00:00Z", "2021-10-01T00:00:00Z")
 
     def run_test(self, streams, start_date_1, start_date_2):
         """Instantiate start date according to the desired data set and run the test"""

--- a/tests/test_recharge_start_date.py
+++ b/tests/test_recharge_start_date.py
@@ -23,11 +23,11 @@ class RechargeStartDateTest(RechargeBaseTest):
         self.run_test(streams_2, "2021-09-01T00:00:00Z", "2022-05-01T00:00:00Z")
 
         # streams of 3rd run
-        stream_3 = {'plans'}
-        self.run_test(streams_2, "2022-06-09T00:00:00Z", "2022-06-10T00:00:00Z")
+        streams_3 = {'plans'}
+        self.run_test(streams_3, "2022-06-09T00:00:00Z", "2022-06-10T00:00:00Z")
 
         # rest other streams for 4th run
-        self.run_test(streams - streams_1 - streams_2 - stream_3, "2021-09-01T00:00:00Z", "2021-10-01T00:00:00Z")
+        self.run_test(streams - streams_1 - streams_2 - streams_3, "2021-09-01T00:00:00Z", "2021-10-01T00:00:00Z")
 
     def run_test(self, streams, start_date_1, start_date_2):
         """Instantiate start date according to the desired data set and run the test"""


### PR DESCRIPTION
# Description of change
TDL-19327: Add new endpoint [Plans](https://developer.rechargepayments.com/2021-11/plans) and [Payment Methods](https://developer.rechargepayments.com/2021-11/payment_methods)
- Added new streams Plans and Payment Methods
- Found some fields: `external_plan_name, external_plan_id, external_plan_group_id` that were missing form the API doc but present in the API response. Thus, not added the fields in the schema.
- Added mechanism to only generate catalog if the user as permission to access the API as payment method is only available to some users. [Reference](https://developer.rechargepayments.com/2021-11/payment_methods)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
