### PR TITLE
TDL-19413: Products stream will not be supported in new version for certain PIMs

### DIFF
--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -190,8 +190,8 @@ class RechargeClient:
         if path == 'collections':
             kwargs['headers']['X-Recharge-Version'] = '2021-11'
 
-        # In API Version: 2021-11, Products endpoint is only available for merchants doing a custom integration
-        # with a PIM (Product Information Management) system that isn’t Shopify or BigCommerce.
+        # In API Version: 2021-11, the Products endpoint is only available for merchants doing a custom integration with a PIM
+        # (Product Information Management) system that isn’t Shopify or BigCommerce hence keeping API version 2021-01 for Products.
         # Documentation: https://docs.rechargepayments.com/changelog/2021-11-api-release-notes/#2-products-and-plans
         if path == 'products':
             kwargs['headers']['X-Recharge-Version'] = '2021-01'

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -190,6 +190,12 @@ class RechargeClient:
         if path == 'collections':
             kwargs['headers']['X-Recharge-Version'] = '2021-11'
 
+        # In API Version: 2021-11, Products endpoint is only available for merchants doing a custom integration
+        # with a PIM (Product Information Management) system that isn’t Shopify or BigCommerce.
+        # Documentation: https://docs.rechargepayments.com/changelog/2021-11-api-release-notes/#2-products-and-plans
+        if path == 'products':
+            kwargs['headers']['X-Recharge-Version'] = '2021-01'
+
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent
 

--- a/tap_recharge/schemas/products.json
+++ b/tap_recharge/schemas/products.json
@@ -92,6 +92,19 @@
         },
         "storefront_purchase_options": {
           "type": ["null", "string"]
+        },
+        "modifiable_properties": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -101,6 +114,9 @@
     "updated_at": {
       "type": ["null", "string"],
       "format": "date-time"
+    },
+    "handle": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/tests/unittests/test_products_stream_verison.py
+++ b/tests/unittests/test_products_stream_verison.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest import mock
+from tap_recharge.streams import Products, Collections
+from tap_recharge.client import RechargeClient
+
+class Mockresponse:
+    def __init__(self, json):
+        self.status_code = 200
+        self.raise_error = False
+        self.text = json
+        self.links = {}
+
+    def json(self):
+        return self.text
+
+@mock.patch('requests.Session.request')
+class TestProductsVerison(unittest.TestCase):
+    """
+        Test cases to verify that we are calling 'Products' with API Version: '2021-01'
+    """
+
+    recharge_client = RechargeClient('test_access_token')
+
+    def test_products_stream_version(self, mocked_request):
+        """
+            Test case to verify we are calling stream 'Products' with API Version: '2021-01'
+        """
+        # mock request and return value with data key
+        mocked_request.return_value = Mockresponse({'products': [{'key': 'value'}]})
+
+        # Products object
+        products = Products(self.recharge_client)
+        # function call
+        list(products.get_records())
+
+        # get arguments passed during calling "requests.Session.request"
+        args, kwargs = mocked_request.call_args
+        # get 'headers' for API call
+        request_headers = kwargs.get('headers')
+
+        # verify we using API Version: '2021-01'
+        self.assertEqual(request_headers.get('X-Recharge-Version'), '2021-01')
+
+    def test_non_products_stream_version(self, mocked_request):
+        """
+            Test case to verify we are calling stream other than 'Products' with API Version: '2021-11'
+        """
+        # mock request and return value with data key
+        mocked_request.return_value = Mockresponse({'collections': [{'key': 'value'}]})
+
+        # Collections object
+        collections = Collections(self.recharge_client)
+        # function call
+        list(collections.get_records())
+
+        # get arguments passed during calling "requests.Session.request"
+        args, kwargs = mocked_request.call_args
+        # get 'headers' for API call
+        request_headers = kwargs.get('headers')
+
+        # verify we using API Version: '2021-11'
+        self.assertEqual(request_headers.get('X-Recharge-Version'), '2021-11')

--- a/tests/unittests/test_products_stream_verison.py
+++ b/tests/unittests/test_products_stream_verison.py
@@ -13,7 +13,6 @@ class Mockresponse:
     def json(self):
         return self.text
 
-@mock.patch('requests.Session.request')
 class TestProductsVerison(unittest.TestCase):
     """
         Test cases to verify that we are calling 'Products' with API Version: '2021-01'
@@ -21,41 +20,29 @@ class TestProductsVerison(unittest.TestCase):
 
     recharge_client = RechargeClient('test_access_token')
 
+    @mock.patch('requests.Session.request', return_value=Mockresponse({'products': [{'key': 'value'}]}))
     def test_products_stream_version(self, mocked_request):
         """
             Test case to verify we are calling stream 'Products' with API Version: '2021-01'
         """
-        # mock request and return value with data key
-        mocked_request.return_value = Mockresponse({'products': [{'key': 'value'}]})
-
-        # Products object
         products = Products(self.recharge_client)
-        # function call
         list(products.get_records())
 
-        # get arguments passed during calling "requests.Session.request"
         args, kwargs = mocked_request.call_args
-        # get 'headers' for API call
         request_headers = kwargs.get('headers')
 
         # verify we using API Version: '2021-01'
         self.assertEqual(request_headers.get('X-Recharge-Version'), '2021-01')
 
+    @mock.patch('requests.Session.request', return_value=Mockresponse({'collections': [{'key': 'value'}]}))
     def test_non_products_stream_version(self, mocked_request):
         """
             Test case to verify we are calling stream other than 'Products' with API Version: '2021-11'
         """
-        # mock request and return value with data key
-        mocked_request.return_value = Mockresponse({'collections': [{'key': 'value'}]})
-
-        # Collections object
         collections = Collections(self.recharge_client)
-        # function call
         list(collections.get_records())
 
-        # get arguments passed during calling "requests.Session.request"
         args, kwargs = mocked_request.call_args
-        # get 'headers' for API call
         request_headers = kwargs.get('headers')
 
         # verify we using API Version: '2021-11'


### PR DESCRIPTION
# Description of change
TDL-19413: Products stream will not be supported in new version for certain PIMs
- Updated the code to use Old API Verison (2021-01) for the Products stream.
- **NOTE:** In the [API Changelog](https://docs.rechargepayments.com/changelog/2021-11-api-release-notes/#2-products-and-plans) it is mentioned that to get Products in New Version: 2021-11 we can use `/plans`, but we have found major field changes ([Tap-Recharge_ Products vs Plans.pdf](https://github.com/singer-io/tap-recharge/files/8907490/Tap-Recharge_.Products.vs.Plans.pdf)) for Plans endpoint thus, we will use Old Verison for this endpoint.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
