### PR TITLE
Cleanup `customers` schema; add ipdb to dev install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='tap-recharge',
       },
       extras_require={
           'dev': [
-              'pylint'
+              'pylint',
+              'ipdb'
           ]
       })

--- a/tap_recharge/schemas/customers.json
+++ b/tap_recharge/schemas/customers.json
@@ -5,84 +5,6 @@
     "id": {
       "type": ["null", "integer"]
     },
-    "hash": {
-      "type": ["null", "string"]
-    },
-    "shopify_customer_id": {
-      "type": ["null", "string"]
-    },
-    "email": {
-      "type": ["null", "string"]
-    },
-    "created_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "updated_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "first_name": {
-      "type": ["null", "string"]
-    },
-    "last_name": {
-      "type": ["null", "string"]
-    },
-    "billing_address1": {
-      "type": ["null", "string"]
-    },
-    "billing_address2": {
-      "type": ["null", "string"]
-    },
-    "billing_zip": {
-      "type": ["null", "string"]
-    },
-    "billing_city": {
-      "type": ["null", "string"]
-    },
-    "billing_company": {
-      "type": ["null", "string"]
-    },
-    "billing_province": {
-      "type": ["null", "string"]
-    },
-    "billing_country": {
-      "type": ["null", "string"]
-    },
-    "billing_phone": {
-      "type": ["null", "string"]
-    },
-    "processor_type": {
-      "type": ["null", "string"]
-    },
-    "status": {
-      "type": ["null", "string"]
-    },
-    "paypal_customer_token": {
-      "type": ["null", "string"]
-    },
-    "braintree_customer_token": {
-      "type": ["null", "string"]
-    },
-    "has_valid_payment_method": {
-      "type": ["null", "boolean"]
-    },
-    "reason_payment_method_not_valid": {
-      "type": ["null", "string"]
-    },
-    "has_card_error_in_dunning": {
-      "type": ["null", "boolean"]
-    },
-    "number_active_subscriptions": {
-      "type": ["null", "integer"]
-    },
-    "number_subscriptions": {
-      "type": ["null", "integer"]
-    },
-    "first_charge_processed_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
     "analytics_data": {
       "type": ["null", "object"],
       "additionalProperties": false,
@@ -126,6 +48,13 @@
         }
       }
     },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
     "external_customer_id": {
       "type": ["null", "object"],
       "additionalProperties": false,
@@ -135,14 +64,34 @@
         }
       }
     },
+    "first_charge_processed_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "first_name": {
+      "type": ["null", "string"]
+    },
     "has_payment_method_in_dunning": {
       "type": ["null", "boolean"]
+    },
+    "has_valid_payment_method": {
+      "type": ["null", "boolean"]
+    },
+    "hash": {
+      "type": ["null", "string"]
+    },
+    "last_name": {
+      "type": ["null", "string"]
     },
     "subscriptions_active_count": {
       "type": ["null", "integer"]
     },
     "subscriptions_total_count": {
       "type": ["null", "integer"]
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }


### PR DESCRIPTION
# Description of change
- Removes several fields from the customers schema as they are not returned by Recharge and are not documented within [their customers object documentation](https://developer.rechargepayments.com/2021-11/customers/customers_object).
- Re-orders the fields listed in the customers.json schema file to alphabetize properties and match Recharge docs for easier long-term maintenance.
- Adds ipdb to the dev install

# Manual QA steps
 - Validated object structure via direct API response
 -  Successful sync locally
 
# Risks
 - User may be confused as to why these fields are no longer available for selection, but fields are filtered during transform for this tap, so there's no change to request structure.
 
# Rollback steps
 - revert this branch
