### PR TITLE
Cleanup `customer` schema, remove one (deprecated) field; add ipdb.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='tap-recharge',
       },
       extras_require={
           'dev': [
-              'pylint'
+              'pylint',
+              'ipdb'
           ]
       })

--- a/tap_recharge/schemas/customers.json
+++ b/tap_recharge/schemas/customers.json
@@ -5,84 +5,6 @@
     "id": {
       "type": ["null", "integer"]
     },
-    "hash": {
-      "type": ["null", "string"]
-    },
-    "shopify_customer_id": {
-      "type": ["null", "string"]
-    },
-    "email": {
-      "type": ["null", "string"]
-    },
-    "created_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "updated_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "first_name": {
-      "type": ["null", "string"]
-    },
-    "last_name": {
-      "type": ["null", "string"]
-    },
-    "billing_address1": {
-      "type": ["null", "string"]
-    },
-    "billing_address2": {
-      "type": ["null", "string"]
-    },
-    "billing_zip": {
-      "type": ["null", "string"]
-    },
-    "billing_city": {
-      "type": ["null", "string"]
-    },
-    "billing_company": {
-      "type": ["null", "string"]
-    },
-    "billing_province": {
-      "type": ["null", "string"]
-    },
-    "billing_country": {
-      "type": ["null", "string"]
-    },
-    "billing_phone": {
-      "type": ["null", "string"]
-    },
-    "processor_type": {
-      "type": ["null", "string"]
-    },
-    "status": {
-      "type": ["null", "string"]
-    },
-    "paypal_customer_token": {
-      "type": ["null", "string"]
-    },
-    "braintree_customer_token": {
-      "type": ["null", "string"]
-    },
-    "has_valid_payment_method": {
-      "type": ["null", "boolean"]
-    },
-    "reason_payment_method_not_valid": {
-      "type": ["null", "string"]
-    },
-    "has_card_error_in_dunning": {
-      "type": ["null", "boolean"]
-    },
-    "number_active_subscriptions": {
-      "type": ["null", "integer"]
-    },
-    "number_subscriptions": {
-      "type": ["null", "integer"]
-    },
-    "first_charge_processed_at": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
     "analytics_data": {
       "type": ["null", "object"],
       "additionalProperties": false,
@@ -126,6 +48,40 @@
         }
       }
     },
+    "billing_address1": {
+      "type": ["null", "string"]
+    },
+    "billing_address2": {
+      "type": ["null", "string"]
+    },
+    "billing_zip": {
+      "type": ["null", "string"]
+    },
+    "billing_city": {
+      "type": ["null", "string"]
+    },
+    "billing_company": {
+      "type": ["null", "string"]
+    },
+    "billing_province": {
+      "type": ["null", "string"]
+    },
+    "billing_country": {
+      "type": ["null", "string"]
+    },
+    "billing_phone": {
+      "type": ["null", "string"]
+    },
+    "braintree_customer_token": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
     "external_customer_id": {
       "type": ["null", "object"],
       "additionalProperties": false,
@@ -135,14 +91,55 @@
         }
       }
     },
+    "first_charge_processed_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "first_name": {
+      "type": ["null", "string"]
+    },
+    "has_card_error_in_dunning": {
+      "type": ["null", "boolean"]
+    },
     "has_payment_method_in_dunning": {
       "type": ["null", "boolean"]
+    },
+    "has_valid_payment_method": {
+      "type": ["null", "boolean"]
+    },
+    "hash": {
+      "type": ["null", "string"]
+    },
+    "last_name": {
+      "type": ["null", "string"]
+    },
+    "number_active_subscriptions": {
+      "type": ["null", "integer"]
+    },
+    "number_subscriptions": {
+      "type": ["null", "integer"]
+    },
+    "paypal_customer_token": {
+      "type": ["null", "string"]
+    },
+    "processor_type": {
+      "type": ["null", "string"]
+    },
+    "reason_payment_method_not_valid": {
+      "type": ["null", "string"]
+    },
+    "status": {
+      "type": ["null", "string"]
     },
     "subscriptions_active_count": {
       "type": ["null", "integer"]
     },
     "subscriptions_total_count": {
       "type": ["null", "integer"]
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tests/test_recharge_bookmark.py
+++ b/tests/test_recharge_bookmark.py
@@ -28,6 +28,8 @@ class RechargeBookmarkTest(RechargeBaseTest):
         """
 
         expected_streams = self.expected_streams()
+        # BUG https://jira.talendforge.org/browse/TDL-20783
+        expected_streams = expected_streams - {"onetimes"}
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
 

--- a/tests/test_recharge_pagination.py
+++ b/tests/test_recharge_pagination.py
@@ -22,8 +22,10 @@ class RechargePaginationTest(RechargeBaseTest):
             "customers",
             "discounts",
             "metafields_subscription",
-            "onetimes",
+            # BUG https://jira.talendforge.org/browse/TDL-20783
+            # "onetimes",
             ]
+
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # table and field selection

--- a/tests/test_recharge_start_date.py
+++ b/tests/test_recharge_start_date.py
@@ -34,6 +34,8 @@ class RechargeStartDateTest(RechargeBaseTest):
         self.start_date = self.start_date_1
 
         expected_streams = streams
+        # BUG https://jira.talendforge.org/browse/TDL-20783
+        expected_streams = streams - {"onetimes"}
         expected_replication_methods = self.expected_replication_method()
 
         ##########################################################################


### PR DESCRIPTION
# Description of change
- Re-orders the fields listed in the customers.json schema file to alphabetize properties and match Recharge docs for easier long-term maintenance.
- Removes the `shopify_customer_id` field which has been removed by Recharge in favor of the `external_customer_id` object
- Adds ipdb to the dev install

# Manual QA steps
 - Validated object structure via direct API response
 - Successful sync locally
 
# Risks
 - Users may be confused as to why this field is no longer available for selection, but fields are filtered during transform for this tap, so there's no change to request structure and it is not being returned by Recharge on this API version.
 
# Rollback steps
 - revert this branch
