### PR TITLE
TDL-24640 - Retry ChunkedEncodingError to fix IncompleteRead errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-recharge/bin/activate
-            pylint tap_recharge --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,no-else-raise,raise-missing-from,inconsistent-return-statements,line-too-long'
+            pylint tap_recharge --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,no-else-raise,raise-missing-from,inconsistent-return-statements,line-too-long,broad-exception-raised'
       - run:
           name: 'Unit Tests'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.2
+  * Adds ChunkedEncodingError to backoff handling
+  * Adds unittest
+  * [#42](https://github.com/singer-io/tap-recharge/pull/42)
+
 ## 2.0.1
   * Removes deprecated `shopify_customer_id` field
   * Re-orders customers.json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='2.0.1',
+      version='2.0.2',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_recharge/client.py
+++ b/tap_recharge/client.py
@@ -4,7 +4,7 @@ import requests
 
 import singer
 from singer import metrics, utils
-from requests.exceptions import Timeout
+from requests.exceptions import Timeout, ChunkedEncodingError
 
 LOGGER = singer.get_logger()
 REQUEST_TIMEOUT = 600
@@ -189,7 +189,7 @@ class RechargeClient:
     # Backoff the request for 5 times when Timeout or Connection error occurs
     @backoff.on_exception(
         backoff.expo,
-        (Timeout, requests.ConnectionError, Server5xxError),
+        (Timeout, requests.ConnectionError, Server5xxError, ChunkedEncodingError),
         max_tries=5,
         factor=2)
     def __enter__(self):
@@ -221,7 +221,7 @@ class RechargeClient:
     # Added backoff for 5 times when Timeout error occurs
     @backoff.on_exception(
         backoff.expo,
-        (Timeout, Server5xxError, requests.ConnectionError, RechargeRateLimitError),
+        (Timeout, Server5xxError, requests.ConnectionError, RechargeRateLimitError, ChunkedEncodingError),
         max_tries=5,
         factor=2)
     # Call/rate limit: https://docs.rechargepayments.com/docs/api-rate-limits

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -3,7 +3,6 @@ from unittest import mock
 from parameterized import parameterized
 from requests.exceptions import Timeout, ConnectionError, ChunkedEncodingError
 from tap_recharge.client import RechargeClient, RechargeRateLimitError, Server5xxError
-import jsonlines
 
 class MockResponse:
     def __init__(self,  status_code, json):


### PR DESCRIPTION
# Description of change
Adds logic to retry ChunkedEncodingErrors in order to fix IncompleteRead errors during extraction.
Adds corresponding unittest

# Manual QA steps
 - Wrote unittest
 
# Risks
 - minimal
 
# Rollback steps
 - revert this branch
