### PR TITLE
Remove support of page based pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.5
+## 2.1.0
   * Remove support of page based pagination.
   * [#45](https://github.com/singer-io/tap-recharge/pull/45)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.5
+  * Remove support of page based pagination.
+  * [#45](https://github.com/singer-io/tap-recharge/pull/45)
+
 ## 2.0.4
   * Fix Dependabot issue
   * [#44](https://github.com/singer-io/tap-recharge/pull/44)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='2.0.4',
+      version='2.0.5',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-recharge',
-      version='2.0.5',
+      version='2.1.0',
       description='Singer.io tap for extracting data from the ReCharge Payments API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_recharge/streams.py
+++ b/tap_recharge/streams.py
@@ -202,34 +202,6 @@ class FullTableStream(BaseStream):
         return state
 
 
-class PageBasedPagingStream(IncrementalStream):
-    """
-    A generic page based pagination implementation for the Recharge API.
-
-    Docs: https://developer.rechargepayments.com/?python#page-based-pagination
-    """
-
-    def get_records(
-            self,
-            bookmark_datetime: datetime = None,
-            is_parent: bool = False) -> Iterator[list]:
-        page = 1
-        self.params.update({
-            'limit': MAX_PAGE_LIMIT,
-            'page': page
-            })
-        result_size = MAX_PAGE_LIMIT
-
-        while result_size == MAX_PAGE_LIMIT:
-            records = self.client.get(self.path, params=self.params)
-
-            result_size = len(records.get(self.data_key))
-            page += 1
-            self.params.update({'page': page})
-
-            yield from records.get(self.data_key)
-
-
 class CursorPagingStream(IncrementalStream):
     """
     A generic cursor pagination implemantation for the Recharge API.
@@ -389,7 +361,7 @@ class MetafieldsSubscription(CursorPagingStream):
     data_key = 'metafields'
 
 
-class Onetimes(PageBasedPagingStream):
+class Onetimes(CursorPagingStream):
     """
     Retrieves non-recurring line items on queued orders from the Recharge API.
 


### PR DESCRIPTION
# Description of change
- Remove support of page-based pagination as it is going to deprecate soon.

Also, we found that, according to this [document](https://changelog.getrecharge.com/upcoming-change-to-recharge-api---90-day-lookback-limit-for-processed-charges-1t2zjW), charges processed over 90 days ago will no longer appear in the results. No technical change is required for this. But, we need to update stitch documentation for this

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
